### PR TITLE
Disable charging sound on macOS

### DIFF
--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -84,6 +84,9 @@
         "com.apple.mouse.scaling" = 1.0;
         "com.apple.scrollwheel.scaling" = 0.4412;
       };
+      "com.apple.PowerChime" = {
+        ChimeOnAllHardware = false;
+      };
     };
   };
 


### PR DESCRIPTION
Add PowerChime configuration to disable the sound that plays when connecting the power adapter.