### PR TITLE
Add codewindow.nvim minimap plugin

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1532,8 +1532,9 @@
     # Extra Plugins
     # ========================================
     extraPlugins = with pkgs.vimPlugins; [
-      onedarkpro-nvim # カラースキーム
-      snacks-nvim     # claudecode.nvimの依存
+      onedarkpro-nvim  # カラースキーム
+      snacks-nvim      # claudecode.nvimの依存
+      codewindow-nvim  # ミニマップ
       (pkgs.vimUtils.buildVimPlugin {
         name = "claudecode.nvim";
         src = pkgs.fetchFromGitHub {
@@ -1569,6 +1570,11 @@
 
       -- claudecode.nvim setup
       require("claudecode").setup()
+
+      -- codewindow.nvim setup
+      local codewindow = require("codewindow")
+      codewindow.setup()
+      codewindow.apply_default_keybinds()
     '';
   };
 }


### PR DESCRIPTION
Enable gorbit99/codewindow.nvim from pkgs.vimPlugins with default keybinds:
  <leader>mo  open minimap
  <leader>mc  close minimap
  <leader>mf  toggle focus
  <leader>mm  toggle minimap

https://claude.ai/code/session_01CXSKXwLerzUcKcgqYQQU7c