### PR TITLE
bufferline: ❌ボタンでウィンドウを閉じずバッファのみ削除

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -443,6 +443,10 @@
       # Bufferline (バッファタブ)
       bufferline = {
         enable = true;
+        settings.options = {
+          close_command.__raw = "function(bufnum) vim.cmd('Bdelete! ' .. bufnum) end";
+          right_mouse_command.__raw = "function(bufnum) vim.cmd('Bdelete! ' .. bufnum) end";
+        };
       };
 
       # Indent-blankline


### PR DESCRIPTION
close_command と right_mouse_command を Bdelete! に変更し、 マウスでタブの❌を押した際もウィンドウを維持したままバッファを閉じるようにする。

https://claude.ai/code/session_01DuAy4asXS7cVR5zaT8egMr