### PR TITLE
fix: which-key に <leader>n と <leader>m のグループ登録を追加

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1371,6 +1371,8 @@
         { "<leader>y", group = "Yank" },
         { "<leader>g", group = "Git" },
         { "<leader>a", group = "AI/Claude" },
+        { "<leader>n", group = "New" },
+        { "<leader>m", group = "Minimap" },
       })
 
       require('auto-session').setup({


### PR DESCRIPTION
## 問題

`<leader>n`（`np`: 新バッファ）と `<leader>m`（`mm/mo/mc/mf`: Minimap）の
プレフィックスが which-key に未登録のため、一文字目入力後にヒント（案内）が
表示されなかった。

## 修正内容

`wk.add()` に以下のグループを追加：

- `<leader>n` → `"New"`
- `<leader>m` → `"Minimap"`

これにより `<leader>n` または `<leader>m` を入力した時点で which-key が
サブコマンドの一覧を表示するようになります。

https://claude.ai/code/session_01CqwogXQD2y1HUJvHYykXRi