### PR TITLE
Set fish as default shell for Snacks terminal keybindings

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -797,25 +797,25 @@
       {
         mode = ["n" "t"];
         key = "<C-\\>";
-        action.__raw = "function() Snacks.terminal.toggle() end";
+        action.__raw = "function() Snacks.terminal.toggle(\"fish\") end";
         options.desc = "Toggle terminal";
       }
       {
         mode = "n";
         key = "<leader>tf";
-        action.__raw = "function() Snacks.terminal.toggle(nil, { win = { style = \"float\" } }) end";
+        action.__raw = "function() Snacks.terminal.toggle(\"fish\", { win = { style = \"float\" } }) end";
         options.desc = "Float terminal";
       }
       {
         mode = "n";
         key = "<leader>th";
-        action.__raw = "function() Snacks.terminal.toggle(nil, { win = { position = \"bottom\", height = 0.3 } }) end";
+        action.__raw = "function() Snacks.terminal.toggle(\"fish\", { win = { position = \"bottom\", height = 0.3 } }) end";
         options.desc = "Horizontal terminal";
       }
       {
         mode = "n";
         key = "<leader>tv";
-        action.__raw = "function() Snacks.terminal.toggle(nil, { win = { position = \"right\", width = 0.4 } }) end";
+        action.__raw = "function() Snacks.terminal.toggle(\"fish\", { win = { position = \"right\", width = 0.4 } }) end";
         options.desc = "Vertical terminal";
       }
       {


### PR DESCRIPTION
## Summary
Updated all Snacks terminal toggle keybindings to explicitly use `fish` as the default shell instead of relying on the system default (nil).

## Changes
- Modified 4 terminal keybindings to pass `"fish"` as the first argument to `Snacks.terminal.toggle()`:
  - `<C-\>` - Toggle terminal (normal and terminal modes)
  - `<leader>tf` - Float terminal
  - `<leader>th` - Horizontal terminal
  - `<leader>tv` - Vertical terminal

## Details
Previously, all terminal toggles used `nil` as the shell argument, which would use the system default shell. This change ensures that fish shell is consistently used across all terminal windows opened through these keybindings, providing a more predictable and uniform terminal experience.

https://claude.ai/code/session_01UHZxTZv1BzvfdvGE9Nt2Ft