### PR TITLE
Configure neominimap.nvim with custom width and keybindings

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1519,7 +1519,7 @@
       require("claudecode").setup()
 
       -- neominimap.nvim setup (v3以降は vim.g.neominimap で設定)
-      vim.g.neominimap = { auto_enable = true, win_width = 14 }
+      vim.g.neominimap = { auto_enable = true, win_width = 14, win_opt = { signcolumn = "no" } }
 
       -- キーマップ (codewindow と同様の <leader>m プレフィックス)
       vim.keymap.set("n", "<leader>mm", "<cmd>Neominimap Toggle<cr>", { desc = "Toggle minimap" })

--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1523,8 +1523,8 @@
 
       -- キーマップ (codewindow と同様の <leader>m プレフィックス)
       vim.keymap.set("n", "<leader>mm", "<cmd>Neominimap Toggle<cr>", { desc = "Toggle minimap" })
-      vim.keymap.set("n", "<leader>mo", "<cmd>Neominimap On<cr>",     { desc = "Open minimap" })
-      vim.keymap.set("n", "<leader>mc", "<cmd>Neominimap Off<cr>",    { desc = "Close minimap" })
+      vim.keymap.set("n", "<leader>mo", "<cmd>Neominimap Enable<cr>",  { desc = "Open minimap" })
+      vim.keymap.set("n", "<leader>mc", "<cmd>Neominimap Disable<cr>", { desc = "Close minimap" })
       vim.keymap.set("n", "<leader>mf", "<cmd>Neominimap Focus<cr>",  { desc = "Focus minimap" })
     '';
   };

--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1519,7 +1519,7 @@
       require("claudecode").setup()
 
       -- neominimap.nvim setup (v3以降は vim.g.neominimap で設定)
-      vim.g.neominimap = { auto_enable = true }
+      vim.g.neominimap = { auto_enable = true, win_width = 14 }
 
       -- キーマップ (codewindow と同様の <leader>m プレフィックス)
       vim.keymap.set("n", "<leader>mm", "<cmd>Neominimap Toggle<cr>", { desc = "Toggle minimap" })


### PR DESCRIPTION
## Summary
Updated neominimap.nvim configuration to improve the minimap appearance and fix keybindings to match the current plugin API.

## Key Changes
- **Configuration**: Added `win_width = 14` and `win_opt = { signcolumn = "no" }` to neominimap setup for better visual appearance
- **Keybindings**: Updated minimap control commands to use the correct API:
  - Changed `<leader>mo` from `Neominimap On` to `Neominimap Enable`
  - Changed `<leader>mc` from `Neominimap Off` to `Neominimap Disable`

## Details
These changes ensure compatibility with neominimap.nvim v3+ by using the correct command names (`Enable`/`Disable` instead of `On`/`Off`). The configuration also customizes the minimap window width to 14 characters and disables the sign column in the minimap for a cleaner appearance.

https://claude.ai/code/session_012DfePxCuwpWtsb5WNFCj8u