### PR TITLE
Improve git blame highlight visibility with custom color

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -257,6 +257,7 @@
           delay = 0;
           message_template = "<author>, <date> - <summary>";
           date_format = "%Y-%m-%d %H:%M:%S";
+          highlight_group = "GitBlame";
         };
       };
       # Autopairs
@@ -1499,6 +1500,9 @@
       vim.api.nvim_set_hl(0, "RainbowGreen", { fg = "#98C379" })
       vim.api.nvim_set_hl(0, "RainbowViolet", { fg = "#C678DD" })
       vim.api.nvim_set_hl(0, "RainbowCyan", { fg = "#56B6C2" })
+
+      -- gitblame の文字色がコメントと被って見づらいため専用のハイライトを定義
+      vim.api.nvim_set_hl(0, "GitBlame", { fg = "#4A88C7", italic = true })
     '';
 
     # ========================================


### PR DESCRIPTION
## Summary
Added a custom highlight group for git blame annotations to improve visibility and prevent color conflicts with comment syntax highlighting.

## Changes
- Added `highlight_group = "GitBlame"` configuration to the git-blame plugin settings
- Defined a new `GitBlame` highlight group with a distinct blue color (`#4A88C7`) and italic styling to differentiate it from comment text

## Details
The git blame plugin was previously using a highlight color that blended in with comment syntax highlighting, making blame annotations difficult to read. This change introduces a dedicated highlight group with a custom blue color and italic styling to ensure git blame information stands out clearly in the editor.

https://claude.ai/code/session_01DczrnMVeQC82gBSfvSiSA2