### PR TITLE
Configure Helix OS editor preset to use nvim-remote

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -233,6 +233,9 @@ in
       gui = {
         language = "ja";
       };
+      os = {
+        editPreset = "nvim-remote";
+      };
     };
   };
   programs.helix = {


### PR DESCRIPTION
## Summary
Added OS-level configuration for Helix editor to use `nvim-remote` as the external editor preset.

## Changes
- Added `os` configuration section under Helix settings
- Set `editPreset` to `"nvim-remote"` to use remote Neovim as the external editor

## Details
This configuration allows Helix to delegate external editor operations to a remote Neovim instance, enabling better integration with existing Neovim workflows and configurations.

https://claude.ai/code/session_018aqPq6JGnSFtf3mftNkhTa