### PR TITLE
Add word deletion keybindings in insert mode

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -480,6 +480,19 @@
         action = "<C-\\><C-n>";
         options.desc = "Exit terminal mode";
       }
+      # Opt+Deleteで単語削除（テキストボックスと同じ挙動）
+      {
+        mode = "i";
+        key = "<M-BS>";
+        action = "<C-w>";
+        options.desc = "Delete word before cursor";
+      }
+      {
+        mode = "i";
+        key = "<M-Del>";
+        action = "<C-o>dw";
+        options.desc = "Delete word after cursor";
+      }
 
       # ===== comment ======
       {


### PR DESCRIPTION
## Summary
Added two new keybindings in insert mode to enable word deletion functionality that matches standard text editor behavior (similar to macOS textbox behavior).

## Key Changes
- Added `<M-BS>` (Alt+Backspace) keybinding to delete the word before the cursor using `<C-w>`
- Added `<M-Del>` (Alt+Delete) keybinding to delete the word after the cursor using `<C-o>dw`

## Implementation Details
Both keybindings are configured for insert mode (`mode = "i"`) with descriptive labels for clarity. The implementation leverages Vim's built-in word deletion commands (`<C-w>` for backward deletion and `dw` for forward deletion).

https://claude.ai/code/session_01HY1KkeBixUJzJJ5bb1QvHS