### PR TITLE
Add smart word operation keybindings (yw/yW/dw/dW)

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -481,6 +481,32 @@
         options.desc = "Exit terminal mode";
       }
 
+      # ===== yw/yW/dw/dW: 単語先頭から操作 =====
+      {
+        mode = "n";
+        key = "yw";
+        action.__raw = "smart_word_op('y', false)";
+        options.desc = "Yank from word start";
+      }
+      {
+        mode = "n";
+        key = "yW";
+        action.__raw = "smart_word_op('y', true)";
+        options.desc = "Yank from WORD start";
+      }
+      {
+        mode = "n";
+        key = "dw";
+        action.__raw = "smart_word_op('d', false)";
+        options.desc = "Delete from word start";
+      }
+      {
+        mode = "n";
+        key = "dW";
+        action.__raw = "smart_word_op('d', true)";
+        options.desc = "Delete from WORD start";
+      }
+
       # ===== comment ======
       {
         mode = "n";
@@ -1532,6 +1558,24 @@
 
     # Rainbow highlight colors - snacks.indent用
     extraConfigLuaPre = ''
+      -- yw/yW/dw/dW を単語の先頭から開始するようにする
+      -- (カーソルが単語の途中にあっても、その単語の先頭まで戻ってから操作する)
+      _G.smart_word_op = function(op, big)
+        return function()
+          local count = vim.v.count1
+          local col = vim.fn.col('.')
+          local char = vim.fn.getline('.'):sub(col, col)
+          if char ~= '' and not char:match('%s') then
+            local boundary = big and [[\(^\|\s\)\zs\S]] or [[\<]]
+            local pos = vim.fn.searchpos(boundary, 'bcn')
+            if pos[1] ~= 0 then
+              vim.fn.cursor(pos[1], pos[2])
+            end
+          end
+          vim.cmd('normal! ' .. count .. op .. (big and 'W' or 'w'))
+        end
+      end
+
       -- nvim-treesitter と Neovim 0.11.x のバージョン不一致対応
       -- nvim-treesitter (新) が Neovim 本体に委譲した述語を手動登録する
       vim.treesitter.query.add_predicate("is-not?", function()

--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1565,7 +1565,7 @@
           local count = vim.v.count1
           local col = vim.fn.col('.')
           local char = vim.fn.getline('.'):sub(col, col)
-          if char ~= '' and not char:match('%s') then
+          if char ~= "" and not char:match('%s') then
             local boundary = big and [[\(^\|\s\)\zs\S]] or [[\<]]
             local pos = vim.fn.searchpos(boundary, 'bcn')
             if pos[1] ~= 0 then


### PR DESCRIPTION
## Summary
Add new keybindings that enable word operations (yank and delete) to start from the beginning of the word, even when the cursor is positioned in the middle of a word.

## Changes
- Added four new normal mode keybindings:
  - `yw`: Yank from word start (respects word boundaries)
  - `yW`: Yank from WORD start (respects whitespace boundaries)
  - `dw`: Delete from word start (respects word boundaries)
  - `dW`: Delete from WORD start (respects whitespace boundaries)

- Implemented `smart_word_op()` Lua function that:
  - Detects if the cursor is positioned within a word
  - Moves the cursor to the word boundary (start of word/WORD) if needed
  - Executes the requested operation (yank or delete) with proper count support
  - Distinguishes between vim word boundaries (`\<`) and whitespace boundaries (`\(^\|\s\)\zs\S`)

## Implementation Details
The `smart_word_op()` function uses vim's `searchpos()` with backward search (`'bcn'` flags) to locate the appropriate word boundary without moving the cursor permanently, then repositions before executing the operation. This allows natural word-based operations regardless of cursor position within the word.

https://claude.ai/code/session_013UPrUPF26JZooSdpvnyyU6