### PR TITLE
Add nvim-spectre for project-wide search and replace

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -787,6 +787,26 @@
         options.desc = "Find TODOs";
       }
 
+      # ===== Search & Replace (nvim-spectre) =====
+      {
+        mode = "n";
+        key = "<leader>S";
+        action.__raw = "function() require('spectre').toggle() end";
+        options.desc = "Toggle Spectre (search & replace)";
+      }
+      {
+        mode = "n";
+        key = "<leader>sw";
+        action.__raw = "function() require('spectre').open_visual({ select_word = true }) end";
+        options.desc = "Search current word (Spectre)";
+      }
+      {
+        mode = "n";
+        key = "<leader>sf";
+        action.__raw = "function() require('spectre').open_file_search({ select_word = true }) end";
+        options.desc = "Search in current file (Spectre)";
+      }
+
       # ===== LSP =====
       {
         mode = "n";
@@ -1560,6 +1580,8 @@
     extraPlugins = with pkgs.vimPlugins; [
       onedarkpro-nvim  # カラースキーム
       snacks-nvim      # dashboard/picker/terminal/explorer/indent/lazygit/bufdelete
+      plenary-nvim     # nvim-spectre の依存
+      nvim-spectre     # プロジェクト全体の検索・一括置換
       (pkgs.vimUtils.buildVimPlugin {  # ミニマップ
         name = "neominimap.nvim";
         src = pkgs.fetchFromGitHub {
@@ -1586,6 +1608,9 @@
     extraConfigLuaPost = ''
       -- claudecode.nvim setup
       require("claudecode").setup()
+
+      -- nvim-spectre setup
+      require("spectre").setup()
 
       -- neominimap.nvim setup (v3以降は vim.g.neominimap で設定)
       vim.g.neominimap = { auto_enable = true, win_width = 14, win_opt = { signcolumn = "no" } }


### PR DESCRIPTION
## Summary
Integrated nvim-spectre plugin to enable powerful project-wide search and replace functionality in Neovim, with convenient keybindings for common search operations.

## Key Changes
- Added three new keybindings for search and replace operations:
  - `<leader>S`: Toggle Spectre panel
  - `<leader>sw`: Search current word across project
  - `<leader>sf`: Search within current file
- Added `plenary-nvim` and `nvim-spectre` to extraPlugins (plenary is a required dependency)
- Added Spectre plugin initialization in the Lua setup section

## Implementation Details
- Keybindings use raw Lua functions to invoke Spectre's toggle and open functions with appropriate options
- The `select_word` option is enabled for word and file search to automatically populate the search field with the current word
- Plugin setup follows the existing pattern used for other plugins like claudecode.nvim

https://claude.ai/code/session_01Mk64GMF49Ps4RWWPq2qrjA