### PR TITLE
nvim: ミニマップをデフォルトoffに変更

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1671,7 +1671,7 @@ _| \_|   \_/   ___|_|  _| ]],
 
       -- neominimap.nvim setup (v3以降は vim.g.neominimap で設定)
       vim.g.neominimap = {
-        auto_enable = true,
+        auto_enable = false,
         float = {
           minimap_width = 14,
           window_border = "single", -- 境目を描画させる(色は NeominimapBorder ハイライトで指定)


### PR DESCRIPTION
## Summary
- neominimap.nvim の `auto_enable` を `true` → `false` に変更し、起動時にミニマップが自動表示されないようにした
- `<leader>mo` で手動オープン、`<leader>mm` でトグルする運用は既存のキーマップのまま

Closes #65

## Test plan
- [ ] nixvim ビルドが通ることを確認
- [ ] nvim 起動時にミニマップが表示されないことを確認
- [ ] `<leader>mo` / `<leader>mm` でミニマップが開閉できることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_016JApfvBBLoYCuKKofCL1ig)_