### PR TITLE
nvim: gd/gr/giのジャンプ先popupを常に表示し分割アクションを選べるようにする

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -846,6 +846,12 @@
       }
       {
         mode = "n";
+        key = "gD";
+        action.__raw = "function() Snacks.picker.lsp_type_definitions({ auto_confirm = false }) end";
+        options.desc = "Go to type definition (choose action in popup)";
+      }
+      {
+        mode = "n";
         key = "gr";
         action.__raw = "function() Snacks.picker.lsp_references({ auto_confirm = false }) end";
         options.desc = "Go to references (choose action in popup)";

--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -841,38 +841,20 @@
       {
         mode = "n";
         key = "gd";
-        action.__raw = "function() Snacks.picker.lsp_definitions({ confirm = 'edit_vsplit' }) end";
-        options.desc = "Go to definition (vsplit)";
-      }
-      {
-        mode = "n";
-        key = "gD";
-        action.__raw = "function() Snacks.picker.lsp_definitions({ confirm = 'edit_split' }) end";
-        options.desc = "Go to definition (split)";
+        action.__raw = "function() Snacks.picker.lsp_definitions({ auto_confirm = false }) end";
+        options.desc = "Go to definition (choose action in popup)";
       }
       {
         mode = "n";
         key = "gr";
-        action.__raw = "function() Snacks.picker.lsp_references({ confirm = 'edit_vsplit' }) end";
-        options.desc = "Go to references (vsplit)";
-      }
-      {
-        mode = "n";
-        key = "gR";
-        action.__raw = "function() Snacks.picker.lsp_references({ confirm = 'edit_split' }) end";
-        options.desc = "Go to references (split)";
+        action.__raw = "function() Snacks.picker.lsp_references({ auto_confirm = false }) end";
+        options.desc = "Go to references (choose action in popup)";
       }
       {
         mode = "n";
         key = "gi";
-        action.__raw = "function() Snacks.picker.lsp_implementations({ confirm = 'edit_vsplit' }) end";
-        options.desc = "Go to implementation (vsplit)";
-      }
-      {
-        mode = "n";
-        key = "gI";
-        action.__raw = "function() Snacks.picker.lsp_implementations({ confirm = 'edit_split' }) end";
-        options.desc = "Go to implementation (split)";
+        action.__raw = "function() Snacks.picker.lsp_implementations({ auto_confirm = false }) end";
+        options.desc = "Go to implementation (choose action in popup)";
       }
       {
         mode = "n";


### PR DESCRIPTION
## Summary
- `gd`/`gr`/`gi` で snacks.picker の `auto_confirm` を無効化し、ジャンプ先が1件でも常にpopupを表示するようにした
- popup内のデフォルトキー（`<CR>`でジャンプ、`<C-v>`でvsplit、`<C-s>`でsplit、`<Esc>`/`q`で何もせず閉じる）で全アクションを選択できるため、vsplit/split固定だった `gD`/`gR`/`gI` キーマップは不要になり削除して統合した

## Test plan
- [ ] `nix run .#nvim`（または通常の起動フローで）nixvimを再ビルドし、LSPが有効なファイルで `gd`/`gr`/`gi` を実行
- [ ] 結果が1件のときもpopupが表示されることを確認
- [ ] popup上で `<CR>` / `<C-v>` / `<C-s>` / `<Esc>` の各アクションが想定通り動作することを確認

Closes #64

https://claude.ai/code/session_01L9KFEuLRCo8C4xG9XunDH6

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9KFEuLRCo8C4xG9XunDH6)_