### PR TITLE
fix(nvim): claudecode.nvimにdirenv execを適用してdevenv設定を反映

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1673,7 +1673,12 @@ _| \_|   \_/   ___|_|  _| ]],
     # Post setup
     extraConfigLuaPost = ''
       -- claudecode.nvim setup
-      require("claudecode").setup()
+      -- claudecode.nvim はシェルを経由せず claude バイナリを直接起動するため、
+      -- direnv のシェルフックが発火せず devenv の環境変数が反映されない。
+      -- direnv exec でラップして、シェル非依存で devenv の環境変数を読み込む。
+      require("claudecode").setup({
+        terminal_cmd = "direnv exec . claude",
+      })
 
       -- neominimap.nvim setup (v3以降は vim.g.neominimap で設定)
       vim.g.neominimap = {


### PR DESCRIPTION
## Summary
- claudecode.nvim はシェルを経由せず `claude` バイナリを直接起動するため、direnv のシェルフックが発火せず devenv の環境変数が反映されない問題を修正
- `terminal_cmd` を `direnv exec . claude` に設定し、シェル非依存で devenv の環境変数を読み込めるようにした
- 既存の TermOpen autocmd での `claude` 除外（起動直後のプロンプトに `direnv reload` が入力されてしまう問題への対応）はそのまま維持

Fixes #71

## Test plan
- [ ] direnv/devenv管理下のプロジェクトでnvimからClaude Codeを起動し、devenvのコマンド/環境変数が利用可能になっていることを確認
- [ ] direnv非管理下のプロジェクトでも `direnv exec` が問題なく動作し、Claude Codeが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LD65Si2d84D7vBuxgBG5hJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LD65Si2d84D7vBuxgBG5hJ)_