### PR TITLE
nvim: 行末画面内自動折り返しトグルのショートカット追加

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -999,6 +999,13 @@
         action = "<cmd>q<CR>";
         options.desc = "Quit";
       }
+      # 行末画面内自動折り返しのトグル
+      {
+        mode = "n";
+        key = "<leader>uw";
+        action = "<cmd>set wrap!<CR>";
+        options.desc = "Toggle line wrap";
+      }
       {
         mode = "n";
         key = "<leader>Q";

--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1415,6 +1415,7 @@ _| \_|   \_/   ___|_|  _| ]],
         { "<leader>a", group = "AI/Claude" },
         { "<leader>n", group = "New" },
         { "<leader>m", group = "Minimap" },
+        { "<leader>u", group = "UI" },
       })
 
       require('auto-session').setup({


### PR DESCRIPTION
## Summary
- `<leader>uw` で `wrap` オプションをトグルできるようにした

Closes #74

## Test plan
- [ ] nvim で `<leader>uw` を押して折り返し表示がON/OFFされることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ed7qhZN7XZ7SYrjw2ZZnW)_