### PR TITLE
nvim: エクスプローラーで隠しファイルをデフォルト表示

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1295,7 +1295,15 @@
       --   vim-bbye     → snacks.bufdelete
       require("snacks").setup({
         -- Picker (telescope の代替)
-        picker = { enabled = true },
+        picker = {
+          enabled = true,
+          sources = {
+            -- Explorer で隠しファイルもデフォルト表示する
+            explorer = {
+              hidden = true,
+            },
+          },
+        },
 
         -- Dashboard (alpha の代替)
         dashboard = {


### PR DESCRIPTION
## Summary
- snacks.nvim の explorer (picker) はデフォルトで隠しファイルを非表示にしていたため、`picker.sources.explorer.hidden = true` を設定し、デフォルトで隠しファイルも表示されるようにした

## Test plan
- [ ] nvim を起動し、エクスプローラーを開いて `.`始まりのファイルが表示されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_014qC4ySNdtnimF9JnmgFysP)_