### PR TITLE
nvim: ヤンクハイライトを検索ハイライトと別色に分離

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1448,8 +1448,8 @@ _| \_|   \_/   ___|_|  _| ]],
         pattern = '*',
         callback = function()
           vim.highlight.on_yank({
-            higroup = 'IncSearch',  -- ハイライトグループ
-            timeout = 100,          -- 表示時間（ミリ秒）
+            higroup = 'YankHighlight', -- ハイライトグループ（検索ハイライトと区別するため専用色）
+            timeout = 100,             -- 表示時間（ミリ秒）
           })
         end,
       })
@@ -1645,6 +1645,9 @@ _| \_|   \_/   ___|_|  _| ]],
 
       -- ミニマップの境目は自己主張を弱めた色にする(背景に近い色)
       vim.api.nvim_set_hl(0, "NeominimapBorder", { fg = "#3B4048" })
+
+      -- ヤンク時のハイライトが検索ハイライト(IncSearch)と同色で紛らわしいため専用の色を定義
+      vim.api.nvim_set_hl(0, "YankHighlight", { bg = "#98C379", fg = "#282C34" })
     '';
 
     # ========================================


### PR DESCRIPTION
## Summary
- ヤンク時のハイライト(`TextYankPost`)が検索ハイライトと同じ `IncSearch` ハイライトグループを使っていたため、同じ色で表示されていた問題を修正
- 専用の `YankHighlight` ハイライトグループを新規定義し、ヤンク時のハイライトをそちらに切り替え

## Test plan
- [ ] `nix/nixvim.nix` の構文が壊れていないことを確認（sandbox環境に `nix` コマンドが無いためビルド確認は未実施）
- [ ] 実機で `nix run` などにより nvim を起動し、ヤンク時のハイライト色と `/` 検索時のハイライト色が別の色で表示されることを確認

Closes #79


---
_Generated by [Claude Code](https://claude.ai/code/session_01P7FvARVk4qBBtHSuZVDh9m)_