### PR TITLE
nvim: ファイルごとにタブ幅を自動判別する(vim-sleuth)

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -110,7 +110,7 @@
       # True Color
       termguicolors = true;
 
-      # タブ設定
+      # タブ設定 (デフォルト値。sleuthプラグインがファイルごとに自動判別して上書きする)
       expandtab = true;
       shiftwidth = 2;
       tabstop = 2;
@@ -450,6 +450,11 @@
       };
 
       modicator = {
+        enable = true;
+      };
+
+      # ファイルごとにshiftwidth/expandtabを自動判別する
+      sleuth = {
         enable = true;
       };
 


### PR DESCRIPTION
## Summary
- `nix/nixvim.nix` に `vim-sleuth` (nixvim の `plugins.sleuth`) を有効化
- グローバル設定 (`shiftwidth = 2`, `tabstop = 2`, `expandtab = true`) はデフォルト値として残しつつ、開いたファイルの既存インデントをヒューリスティックに検出して `shiftwidth`/`expandtab` を自動調整するようにした

## Context
fsi (F# Interactive) のファイルを編集した際、グローバル設定によりタブ幅が意図せず2になってしまう問題 (#82) に対応。ファイルごとに実際のインデント幅を自動判別することで、ファイルの既存スタイルに合わせて編集できるようになる。

## Test plan
- [ ] `nix build` / `home-manager switch` でビルドが通ることを確認
- [ ] tabstop/shiftwidth が異なるファイル(例: 4スペースインデントのファイル)を開き、自動的にその幅に追従することを確認
- [ ] 既存のグローバル設定 (2スペース) がデフォルトとして機能することを確認

Closes #82


---
_Generated by [Claude Code](https://claude.ai/code/session_01RLXQ9VU4xoGTt4waWQHSE4)_