### PR TITLE
nvim: タブページ操作用のキーバインドを追加

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -672,7 +672,6 @@
         };
       }
       # ===== タブ操作 (AstroNvim風) =====
-      # タブ切り替え自体は標準の gt/gT で足りるため、作成・破棄系のみ用意する
       {
         mode = "n";
         key = "<leader><Tab>n";
@@ -696,6 +695,20 @@
         key = "<leader><Tab>m";
         action = "<C-w>T";
         options.desc = "Move window to new tab";
+      }
+      # 標準の gt/gT でも切り替え可能だが、<leader><Tab> グループ側からも
+      # 一貫して操作できるようにエイリアスを用意する
+      {
+        mode = "n";
+        key = "<leader><Tab>]";
+        action = "<cmd>tabnext<CR>";
+        options.desc = "Next tab";
+      }
+      {
+        mode = "n";
+        key = "<leader><Tab>[";
+        action = "<cmd>tabprevious<CR>";
+        options.desc = "Previous tab";
       }
       # ===== ウィンドウ分割 (AstroNvim風) =====
       {

--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -671,6 +671,32 @@
           desc = "Previous diff";
         };
       }
+      # ===== タブ操作 (AstroNvim風) =====
+      # タブ切り替え自体は標準の gt/gT で足りるため、作成・破棄系のみ用意する
+      {
+        mode = "n";
+        key = "<leader><Tab>n";
+        action = "<cmd>tabnew<CR>";
+        options.desc = "New tab";
+      }
+      {
+        mode = "n";
+        key = "<leader><Tab>c";
+        action = "<cmd>tabclose<CR>";
+        options.desc = "Close tab";
+      }
+      {
+        mode = "n";
+        key = "<leader><Tab>o";
+        action = "<cmd>tabonly<CR>";
+        options.desc = "Close other tabs";
+      }
+      {
+        mode = "n";
+        key = "<leader><Tab>m";
+        action = "<C-w>T";
+        options.desc = "Move window to new tab";
+      }
       # ===== ウィンドウ分割 (AstroNvim風) =====
       {
         mode = "n";
@@ -1403,6 +1429,7 @@ _| \_|   \_/   ___|_|  _| ]],
       local wk = require("which-key")
       wk.add({
         { "<leader>b", group = "Buffer" },
+        { "<leader><Tab>", group = "Tab" },
         { "<leader>f", group = "Find" },
         { "<leader>l", group = "LSP" },
         { "<leader>t", group = "Terminal" },


### PR DESCRIPTION
## Summary
- `gt`/`gT` によるタブ切り替えはあるが、タブの作成手段がなかったため `<leader><Tab>` グループを新設した
- AstroNvim風のキー体系（既存の `|`/`\` ウィンドウ分割コメントに準拠）で新規作成・破棄・移動系を追加
- 次/前タブへの移動も同グループから一貫して行えるようにエイリアスを追加

## 追加したキーバインド

| キー | 動作 | 説明 |
|---|---|---|
| `<leader><Tab>n` | `:tabnew<CR>` | 新規タブ作成 |
| `<leader><Tab>c` | `:tabclose<CR>` | 現在のタブを閉じる |
| `<leader><Tab>o` | `:tabonly<CR>` | 他のタブを全部閉じる |
| `<leader><Tab>m` | `<C-w>T` | 現在のウィンドウを新規タブへ切り出す |
| `<leader><Tab>]` | `:tabnext<CR>` | 次のタブへ移動 |
| `<leader><Tab>[` | `:tabprevious<CR>` | 前のタブへ移動 |

which-key のグループ一覧にも `<leader><Tab>` = "Tab" を追加済み。

Closes #80

## Test plan
- [ ] `nix run .#homeConfigurations.<host>.activationPackage` 等でビルドが通ることを確認
- [ ] Neovim起動後、`<leader><Tab>` を押して which-key に上記6項目が表示されることを確認
- [ ] `<leader><Tab>n` で新規タブが作成され、`]`/`[` で切り替え、`c`/`o`/`m` がそれぞれ期待通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RR9JGeoTSiLajXGyGwNzJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012RR9JGeoTSiLajXGyGwNzJ)_