### PR TITLE
fix: nvimターミナル分割で横/縦がフロートターミナルを開いてしまう問題を修正

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1001,25 +1001,25 @@
       {
         mode = ["n" "t"];
         key = "<C-\\>";
-        action.__raw = "function() Snacks.terminal.toggle(\"fish\") end";
+        action.__raw = "function() Snacks.terminal.toggle(\"fish\", { count = 1 }) end";
         options.desc = "Toggle terminal";
       }
       {
         mode = "n";
         key = "<leader>tf";
-        action.__raw = "function() Snacks.terminal.toggle(\"fish\", { win = { style = \"float\" } }) end";
+        action.__raw = "function() Snacks.terminal.toggle(\"fish\", { win = { style = \"float\" }, count = 2 }) end";
         options.desc = "Float terminal";
       }
       {
         mode = "n";
         key = "<leader>th";
-        action.__raw = "function() Snacks.terminal.toggle(\"fish\", { win = { position = \"bottom\", height = 0.3 } }) end";
+        action.__raw = "function() Snacks.terminal.toggle(\"fish\", { win = { position = \"bottom\", height = 0.3 }, count = 3 }) end";
         options.desc = "Horizontal terminal";
       }
       {
         mode = "n";
         key = "<leader>tv";
-        action.__raw = "function() Snacks.terminal.toggle(\"fish\", { win = { position = \"right\", width = 0.4 } }) end";
+        action.__raw = "function() Snacks.terminal.toggle(\"fish\", { win = { position = \"right\", width = 0.4 }, count = 4 }) end";
         options.desc = "Vertical terminal";
       }
       {


### PR DESCRIPTION
## 概要

`<leader>th`（横分割ターミナル）・`<leader>tv`（縦分割ターミナル）を実行しても、意図した配置ではなくフロートターミナルが開いてしまう不具合を修正しました (#92)。

## 原因

`nix/nixvim.nix` の4つのターミナル用キーマップ（`<C-\>` トグル / `<leader>tf` フロート / `<leader>th` 横分割 / `<leader>tv` 縦分割）は、いずれも `Snacks.terminal.toggle("fish", { win = {...} })` という形で同じコマンド (`fish`) に対して呼び出していました。

`Snacks.terminal` はターミナルインスタンスを `cmd` / `cwd` / `env` / `count` の組み合わせだけで識別しており、`win`（ウィンドウの配置やスタイル）は識別キーに含まれません。そのため4つのキーマップはすべて同一のターミナルインスタンスを共有してしまい、後から呼び出したキーマップは新しい `win` 設定を適用せず、既存インスタンス（最初に開かれた配置＝フロート）をそのまま再表示していました。

## 修正内容

各キーマップに個別の `count` を指定し、それぞれが独立したターミナルインスタンスを保持するようにしました。

```lua
-- Before
Snacks.terminal.toggle("fish", { win = { position = "bottom", height = 0.3 } })

-- After
Snacks.terminal.toggle("fish", { win = { position = "bottom", height = 0.3 }, count = 3 })
```

これにより、トグル・フロート・横分割・縦分割がそれぞれ独立したターミナルとして正しい配置で開くようになります。

## テスト

- nix/home-manager をローカルでビルドできる環境がないため、実機での動作確認は未実施です。差分は既存のキーマップ定義パターンに沿った最小限の変更です。

Fixes #92


---
_Generated by [Claude Code](https://claude.ai/code/session_0127894UnnewEhDH3FbVjj1W)_