### PR TITLE
Fix F# doc comment duplication on trailing space input

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1852,7 +1852,10 @@ _| \_|   \_/   ___|_|  _| ]],
               buffer = args.buf,
               group = vim.api.nvim_create_augroup("FSharpDocCommentBuf" .. args.buf, { clear = true }),
               callback = function()
-                if vim.trim(vim.api.nvim_get_current_line()) == "///" then
+                -- vim.trim()で前後の空白を除去して比較すると、生成済みテンプレートの
+                -- 空行(2行目の"///")に末尾スペースを入力しただけでも一致してしまい、
+                -- 二重生成を招く。末尾に何も無い完全な"///"の場合のみトリガーする。
+                if vim.api.nvim_get_current_line():match("^%s*///$") then
                   local lnum = vim.api.nvim_win_get_cursor(0)[1]
                   fsharp_generate_doc_comment(args.buf, lnum)
                 end


### PR DESCRIPTION
## Summary
- F#ファイルで`///`を入力すると`<summary>`ドキュメントコメントテンプレートを自動生成する仕組み(`nix/nixvim.nix`)で、生成済みテンプレートの空行(2行目の`///`)に末尾スペースを入力しただけで再度生成がトリガーされ、`<summary>`ブロックが二重に入れ子生成される不具合を修正
- トリガー条件を`vim.trim(line) == "///"`(前後の空白を除去して比較)から、`line:match("^%s*///$")`(行頭のインデントのみ許容し末尾には何も無い場合のみ一致)に変更

## Test plan
- [ ] nvimでF#ファイルを開き、`///`と入力してテンプレートが生成されることを確認
- [ ] 生成されたテンプレートの空行にスペースを入力しても二重生成されないことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_013fnginZbESqKTsQt4hbowf)_