### PR TITLE
fix(nvim): pin dotnet-sdk to .NET 10 for fsautocomplete project loading

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -49,7 +49,7 @@ in
     claude-code
     tle
     fd
-    dotnet-sdk
+    dotnet-sdk_10
   ];
   home.file = {
   };


### PR DESCRIPTION
## Summary
- `nix/home.nix` installed the plain `dotnet-sdk` package, which in nixpkgs still resolves to `dotnetCorePackages.sdk_8_0` (.NET 8).
- After a project's `TargetFramework`/`global.json` moves to net10.0, the installed .NET 8 SDK can no longer restore/build it. FsAutoComplete's MSBuild-based project loader (Ionide.ProjInfo) then silently fails to load the project, which is why nvim's `fsautocomplete` reports files as missing from `LoadedProjects` (`-32603: Couldn't find ... in LoadedProjects`).
- Switched the installed package to `dotnet-sdk_10` so the machine's SDK matches projects targeting .NET 10.

## Test plan
- [ ] `nix run .#homeConfigurations.<name>.activationPackage` (or `home-manager switch --flake ~/dotfiles/nix`) to rebuild and confirm `dotnet --list-sdks` shows 10.x
- [ ] Reopen the affected `.fs` file in nvim and confirm `fsautocomplete` loads the project without the `LoadedProjects` error


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLxsUcg4c3LyUU5w4c6xH2)_