### PR TITLE
Disable fsautocomplete semantic tokens to prevent UI freeze

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -352,9 +352,8 @@
         };
       };
       # Autopairs
-      # TODO: F#編集時のフリーズ原因調査のため一時的に無効化(切り分け用)
       nvim-autopairs = {
-        enable = false;
+        enable = true;
       };
 
       # Comment

--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -106,6 +106,23 @@
         '';
         desc = "LSPが対応していれば型注釈などのインレイヒントを自動的に有効化する（VSCode Ionideのような表示）";
       }
+      {
+        event = "LspAttach";
+        callback.__raw = ''
+          function(args)
+            local client = vim.lsp.get_client_by_id(args.data.client_id)
+            -- fsautocompleteのセマンティックトークンは、型注釈なしの多段メソッド
+            -- チェーン(page.Locator(...).Firstのような)を含むバッファでデコード処理が
+            -- 極端に重くなり、nvimがフリーズする不具合を確認したため無効化する。
+            -- 構文ハイライトはtreesitter(fsharpグラマー)で代替できるため実害はない。
+            if client and client.name == "fsautocomplete" then
+              client.server_capabilities.semanticTokensProvider = nil
+              vim.lsp.semantic_tokens.stop(args.buf, client.id)
+            end
+          end
+        '';
+        desc = "fsautocompleteのセマンティックトークンを無効化(フリーズ対策)";
+      }
     ];
     opts = {
       # 行番号

--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -352,8 +352,9 @@
         };
       };
       # Autopairs
+      # TODO: F#編集時のフリーズ原因調査のため一時的に無効化(切り分け用)
       nvim-autopairs = {
-        enable = true;
+        enable = false;
       };
 
       # Comment


### PR DESCRIPTION
## Summary
Added an LSP event handler to disable semantic tokens for the fsautocomplete language server, preventing UI freezes that occur when processing certain F# code patterns.

## Changes
- Added `LspAttach` event callback that detects when fsautocomplete connects
- Disables `semanticTokensProvider` capability and stops semantic token processing for fsautocomplete buffers
- Preserves syntax highlighting through Treesitter's F# grammar as an alternative

## Details
The fsautocomplete semantic token decoder exhibits severe performance degradation when processing multi-method chains without type annotations (e.g., `page.Locator(...).First`), causing Neovim to freeze. This change mitigates the issue by disabling semantic tokens specifically for fsautocomplete while maintaining syntax highlighting through Treesitter, which provides adequate visual feedback without the performance penalty.

https://claude.ai/code/session_01AngrZLTKb3rAJevd8vqWLr