### PR TITLE
nvim: .slnファイルのシンタックスハイライトを追加

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -1508,6 +1508,60 @@ _| \_|   \_/   ___|_|  _| ]],
         end,
       })
 
+      -- .sln (Visual Studio Solution) のファイルタイプ検出
+      vim.filetype.add({
+        extension = {
+          sln = "sln",
+        },
+      })
+
+      -- .sln シンタックスハイライト
+      -- .slnはVisual Studio独自の中間フォーマットで、treesitterの文法(グラマー)が
+      -- 存在しないため、Vim標準のsyntaxコマンドベースで実装する
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = "sln",
+        group = vim.api.nvim_create_augroup("SlnSyntax", { clear = true }),
+        callback = function()
+          if vim.b.current_syntax then
+            return
+          end
+          vim.b.current_syntax = "sln"
+
+          vim.cmd([[
+            syntax match slnComment /^\s*#.*$/
+            syntax match slnHeader /^Microsoft Visual Studio Solution File.*$/
+
+            syntax keyword slnKeyword Project EndProject
+            syntax keyword slnKeyword Global EndGlobal
+            syntax keyword slnKeyword GlobalSection EndGlobalSection
+            syntax keyword slnKeyword ProjectSection EndProjectSection
+            syntax keyword slnKeyword ProjectDependencies NestedProjects
+            syntax keyword slnKeyword VisualStudioVersion MinimumVisualStudioVersion
+
+            syntax keyword slnConstant preSolution postSolution
+            syntax keyword slnBoolean TRUE FALSE
+
+            syntax match slnGuid /{[0-9A-Fa-f]\{8}-[0-9A-Fa-f]\{4}-[0-9A-Fa-f]\{4}-[0-9A-Fa-f]\{4}-[0-9A-Fa-f]\{12}}/
+
+            syntax region slnString start=/"/ skip=/\\"/ end=/"/
+
+            syntax match slnNumber /\<\d\+\%(\.\d\+\)*\>/
+
+            syntax match slnOperator /=/
+
+            highlight default link slnComment Comment
+            highlight default link slnHeader Special
+            highlight default link slnKeyword Keyword
+            highlight default link slnConstant Constant
+            highlight default link slnBoolean Boolean
+            highlight default link slnGuid Identifier
+            highlight default link slnString String
+            highlight default link slnNumber Number
+            highlight default link slnOperator Operator
+          ]])
+        end,
+      })
+
       -- OneDarkPro setup
       require("onedarkpro").setup({
         options = {


### PR DESCRIPTION
## Summary
- Visual Studio Solutionファイル(`.sln`)は独自の中間フォーマットで、nvim-treesitterに対応する文法(グラマー)が存在しないため、Vim標準の`syntax`コマンドベースでハイライトを実装
- `vim.filetype.add`で拡張子`.sln`を`sln`フィルタイプとして検出
- `FileType`autocmdでコメント(`#`)、ヘッダ行、`Project`/`EndProject`/`Global`/`GlobalSection`などのブロックキーワード、GUID、文字列、バージョン番号、`TRUE`/`FALSE`を標準ハイライトグループ(Comment/Keyword/Identifier/String/Number/Boolean等)にリンク

## Test plan
- [ ] `home-manager switch --flake ~/dotfiles/nix#ne0san`でビルドが通ることを確認
- [ ] `.sln`ファイルを開き、`Project(...)`, `GlobalSection(...)`, GUID, コメント行などが色分けされることを目視確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01CKNeDqsAggyeaL7SNxTdBL)_