### PR TITLE
nvim: jjでノーマルモードに戻るショートカットをttに変更

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -560,10 +560,10 @@
         action = "<cmd>nohlsearch<CR>";
         options.desc = "Clear search highlight";
       }
-      # jjでノーマルモードに戻る
+      # ttでノーマルモードに戻る
       {
         mode = "i";
-        key = "jj";
+        key = "tt";
         action = "<Esc>";
         options.desc = "Exit insert mode";
       }
@@ -1093,7 +1093,7 @@
       }
       {
         mode = "t";
-        key = "jj";
+        key = "tt";
         action = "<C-\\><C-n>";
         options.desc = "Exit terminal mode";
       }


### PR DESCRIPTION
## Summary
- nvimに jj (jujutsu) を導入するにあたり、`jj` とノーマルモード復帰ショートカットが衝突するため、インサートモード・ターミナルモード両方の `jj` → `tt` に変更

## Test plan
- [ ] `nix/nixvim.nix` の構文が正しいことを確認（Nixビルド環境で `home-manager switch` 等）
- [ ] nvimでインサートモード中に `tt` を入力してノーマルモードに戻ることを確認
- [ ] ターミナルモード中に `tt` を入力してノーマルモードに戻ることを確認
- [ ] `jj` (jujutsu) コマンドが誤ってノーマルモード復帰として扱われないことを確認

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtFnUPzRSE5uLdARt9HTeE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtFnUPzRSE5uLdARt9HTeE)_