### PR TITLE
nvimでタブ・スペース・改行文字などを可視化

### DIFF
--- a/nix/nixvim.nix
+++ b/nix/nixvim.nix
@@ -196,6 +196,17 @@
       # 分割時の新ウィンドウ配置（vsplitは右、splitは下に新ウィンドウを開く）
       splitright = true;
       splitbelow = true;
+
+      # 不可視文字(タブ・行末スペース・改行位置)の可視化
+      list = true;
+      listchars = {
+        tab = "▸ ";
+        trail = "·";
+        nbsp = "␣";
+        extends = "›";
+        precedes = "‹";
+        eol = "↴";
+      };
     };
 
     # ========================================
@@ -1136,6 +1147,13 @@
         key = "<leader>uw";
         action = "<cmd>set wrap!<CR>";
         options.desc = "Toggle line wrap";
+      }
+      # タブ・行末スペース・改行位置の可視化トグル
+      {
+        mode = "n";
+        key = "<leader>ul";
+        action = "<cmd>set list!<CR>";
+        options.desc = "Toggle invisible characters";
       }
       {
         mode = "n";


### PR DESCRIPTION
## Summary
- `nix/nixvim.nix` の `opts` に `list = true` と `listchars` を追加し、タブ・行末スペース・改行位置(eol)などの不可視文字を可視化
- `<leader>ul` で表示のオン/オフをトグルできるキーマップを追加(既存の `<leader>uw` 行折り返しトグルと同じ `UI` グループ)

## Test plan
- [ ] `nixvim.nix` の記法確認(手元でnixが使えなかったためビルド未実施。適用後 `:set list?` `:set listchars?` で反映確認をお願いします)
- [ ] `<leader>ul` でトグルできることを確認

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P5BHS2y1Kd5HJdmJndbkNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5BHS2y1Kd5HJdmJndbkNj)_