### PR TITLE
starshipでjjの情報を表示、git/jj併存時はjjを優先

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -97,6 +97,9 @@ in
         # jjとgitが共存する場合はjjの情報を優先する
         # closest_bookmark(to) は programs.jujutsu.settings.revset-aliases で定義済み
         vcs_branch = {
+          # shellを明示しないとSTARSHIP_SHELL（fish）経由で実行されてしまい、
+          # 下記の sh/POSIX 構文（if...then...fi 等）がパースエラーになるため固定する
+          shell = [ "sh" ];
           when = "jj root --ignore-working-copy >/dev/null 2>&1 || git rev-parse --is-inside-work-tree >/dev/null 2>&1";
           command = ''
             if jj root --ignore-working-copy >/dev/null 2>&1; then

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -91,14 +91,29 @@ in
       };
 
       custom = {
-        # jjリポジトリ（gitとの共存含む）ではjjのブックマーク・change idを、
+        # jjリポジトリ（gitとの共存含む）では「一番近いbookmark名 + そこからのchange数」
+        # （例: bookmarkの真上なら"main"、1つ先なら"main + 1"）を、
         # 純粋なgitリポジトリではgitのブランチ名を表示する
         # jjとgitが共存する場合はjjの情報を優先する
+        # closest_bookmark(to) は programs.jujutsu.settings.revset-aliases で定義済み
         vcs_branch = {
           when = "jj root --ignore-working-copy >/dev/null 2>&1 || git rev-parse --is-inside-work-tree >/dev/null 2>&1";
           command = ''
             if jj root --ignore-working-copy >/dev/null 2>&1; then
-              jj log --no-graph --color=never -r @ -T 'if(conflict, "💥 ") ++ if(bookmarks, bookmarks ++ " ", "") ++ change_id.shortest(8)' 2>/dev/null
+              conflict=$(jj log --no-graph -r @ -T 'if(conflict, "💥 ")' 2>/dev/null)
+              bm=$(jj log --no-graph -r 'closest_bookmark(@)' -T 'bookmarks.map(|b| b.name()).join(",")' 2>/dev/null)
+              if [ -n "$bm" ]; then
+                dist=$(jj log --no-graph -r 'closest_bookmark(@)..@' -T '"."' 2>/dev/null | wc -c | tr -d ' ')
+                dist=''${dist:-0}
+                if [ "$dist" -gt 0 ]; then
+                  echo "$conflict$bm + $dist"
+                else
+                  echo "$conflict$bm"
+                fi
+              else
+                change_id=$(jj log --no-graph -r @ -T 'change_id.shortest(8)' 2>/dev/null)
+                echo "$conflict$change_id"
+              fi
             else
               git branch --show-current 2>/dev/null
             fi

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -84,8 +84,29 @@ in
         truncate_to_repo = true;
       };
 
+      # ブランチ表示はcustom.vcs_branchに一本化するため無効化
+      # （jjとgitが共存するリポジトリでは、両方の表示が重複してしまうため）
       git_branch = {
-        symbol = "🔧 ";
+        disabled = true;
+      };
+
+      custom = {
+        # jjリポジトリ（gitとの共存含む）ではjjのブックマーク・change idを、
+        # 純粋なgitリポジトリではgitのブランチ名を表示する
+        # jjとgitが共存する場合はjjの情報を優先する
+        vcs_branch = {
+          when = "jj root --ignore-working-copy >/dev/null 2>&1 || git rev-parse --is-inside-work-tree >/dev/null 2>&1";
+          command = ''
+            if jj root --ignore-working-copy >/dev/null 2>&1; then
+              jj log --no-graph --color=never -r @ -T 'if(conflict, "💥 ") ++ if(bookmarks, bookmarks ++ " ", "") ++ change_id.shortest(8)' 2>/dev/null
+            else
+              git branch --show-current 2>/dev/null
+            fi
+          '';
+          symbol = "🔧 ";
+          format = "[$symbol$output]($style) ";
+          style = "bold green";
+        };
       };
 
       env_var = {


### PR DESCRIPTION
## Summary
- `nix/home.nix` の starship 設定に `custom.vcs_branch` モジュールを追加し、jj リポジトリではブックマーク・change id を、git リポジトリではブランチ名を表示するようにした
- 既存の `git_branch` モジュールは無効化し、ブランチ/ブックマーク表示を `custom.vcs_branch` に一本化（jj と git の情報が二重に表示されるのを防ぐため）
- jj と git が共存する（jj のコロケートリポジトリなど）場合は `jj root` の成否を先に判定し、jj の情報を優先して表示する

## Test plan
- [ ] `home-manager switch` （または `drsw`）を実行し、starship の生成設定に `[custom.vcs_branch]` が反映されることを確認
- [ ] 通常の git リポジトリでプロンプトにブランチ名が表示されることを確認
- [ ] jj リポジトリ（jj のみ、および git とのコロケート）でプロンプトに jj のブックマーク・change id が表示されることを確認
- [ ] git/jj のどちらでもないディレクトリでは何も表示されないことを確認

Closes https://github.com/ne0san/dotfiles/issues/113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5Dp373jXFHc7b2GSRQ3iK

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5Dp373jXFHc7b2GSRQ3iK)_