### PR TITLE
home-manager単体出力にLinux向けターゲットを追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,8 @@
 #   nix run nix-darwin -- switch --flake .#ne0san --impure # 初回
 #   sudo darwin-rebuild switch --flake ~/dotfiles#ne0san --impure # 二回目以降 (drsw)
 #
-# home-manager単体 (home.nix + nixvim.nixだけを反映)
+# home-manager単体 (home.nix + nixvim.nixだけを反映。darwin/linux両対応、
+# 実行ホストのsystemを自動判定するため同じコマンドでOK)
 #   nix run home-manager/master -- switch --flake .#ne0san --impure -b backup # 初回
 #   home-manager switch --flake ~/dotfiles#ne0san --impure -b backup # 二回目以降 (hmsw)
 #
@@ -36,12 +37,20 @@
       system = "aarch64-darwin";
       username = builtins.getEnv "USER";
       # home.nixのunfreeパッケージ(1password-cli, claude-code)を許可するpkgs
+      unfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
+        "1password-cli"
+        "claude-code"
+      ];
       pkgs = import nixpkgs {
         inherit system;
-        config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
-          "1password-cli"
-          "claude-code"
-        ];
+        config.allowUnfreePredicate = unfreePredicate;
+      };
+      # home-manager単体は、既にUSER取得で--impure運用な点を踏まえ、
+      # 評価を実行したホストのsystemをそのまま使う(darwin/linux, アーキ問わず自動対応)。
+      # そのためnix flake show/checkのような「今いないホスト」向けの静的な確認はできない。
+      homePkgs = import nixpkgs {
+        system = builtins.currentSystem;
+        config.allowUnfreePredicate = unfreePredicate;
       };
     in {
       # darwin: システム設定(darwin.nix) + home-manager(home.nix, nixvim.nix)をまとめて反映
@@ -68,8 +77,10 @@
       };
 
       # home-manager: home.nix(dotfiles) + nixvim.nixをdarwinを介さず単体で反映
+      # systemは実行ホストのcurrentSystemに従うため、darwin/linux・アーキ問わず同じ
+      # 出力名(ne0san)のまま使える(--impure必須。元々USER取得で必須だったので実質変化なし)
       homeConfigurations."ne0san" = home-manager.lib.homeManagerConfiguration {
-        inherit pkgs;
+        pkgs = homePkgs;
         # home-manager単体モード: home.nix側でdrswを無効化させる
         extraSpecialArgs = { inherit username; darwinManagesHomeManager = false; };
         modules = [

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,9 @@
 #   nix run nix-darwin -- switch --flake .#ne0san --impure # 初回
 #   sudo darwin-rebuild switch --flake ~/dotfiles#ne0san --impure # 二回目以降 (drsw)
 #
-# home-manager単体 (home.nix + nixvim.nixだけを反映、macOS向け)
+# home-manager単体 (home.nix + nixvim.nixだけを反映)
 #   nix run home-manager/master -- switch --flake .#ne0san --impure -b backup # 初回
 #   home-manager switch --flake ~/dotfiles#ne0san --impure -b backup # 二回目以降 (hmsw)
-#
-# home-manager単体 (home.nix + nixvim.nixだけを反映、Linux向け)
-# アーキテクチャに応じて ne0san-linux-x86_64 / ne0san-linux-aarch64 を使い分ける
-#   nix run home-manager/master -- switch --flake .#ne0san-linux-x86_64 --impure -b backup # 初回
-#   home-manager switch --flake ~/dotfiles#ne0san-linux-x86_64 --impure -b backup # 二回目以降 (hmsw)
 #
 # home-managerはmodule統合とstandaloneの併用が非対応で、同じプロファイルを
 # 取り合って壊れる(darwin-rebuildのたびにhome-managerコマンドが消える等)ため、
@@ -41,24 +36,11 @@
       system = "aarch64-darwin";
       username = builtins.getEnv "USER";
       # home.nixのunfreeパッケージ(1password-cli, claude-code)を許可するpkgs
-      unfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
-        "1password-cli"
-        "claude-code"
-      ];
-      mkPkgs = sys: import nixpkgs {
-        system = sys;
-        config.allowUnfreePredicate = unfreePredicate;
-      };
-      pkgs = mkPkgs system;
-      # home-manager単体: home.nix(dotfiles) + nixvim.nixをdarwinを介さず単体で反映
-      mkHomeConfiguration = sys: home-manager.lib.homeManagerConfiguration {
-        pkgs = mkPkgs sys;
-        # home-manager単体モード: home.nix側でdrswを無効化させる
-        extraSpecialArgs = { inherit username; darwinManagesHomeManager = false; };
-        modules = [
-          nixvim.homeModules.nixvim
-          ./nix/home.nix
-          ./nix/nixvim.nix
+      pkgs = import nixpkgs {
+        inherit system;
+        config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
+          "1password-cli"
+          "claude-code"
         ];
       };
     in {
@@ -85,11 +67,16 @@
         specialArgs = { inherit username; };
       };
 
-      # home-manager単体 (macOS): darwinを介さずhome.nix/nixvim.nixだけを反映
-      homeConfigurations."ne0san" = mkHomeConfiguration system;
-
-      # home-manager単体 (Linux): darwin/homebrew前提の設定を切り離した状態で反映
-      homeConfigurations."ne0san-linux-x86_64" = mkHomeConfiguration "x86_64-linux";
-      homeConfigurations."ne0san-linux-aarch64" = mkHomeConfiguration "aarch64-linux";
+      # home-manager: home.nix(dotfiles) + nixvim.nixをdarwinを介さず単体で反映
+      homeConfigurations."ne0san" = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+        # home-manager単体モード: home.nix側でdrswを無効化させる
+        extraSpecialArgs = { inherit username; darwinManagesHomeManager = false; };
+        modules = [
+          nixvim.homeModules.nixvim
+          ./nix/home.nix
+          ./nix/nixvim.nix
+        ];
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,14 @@
 #   nix run nix-darwin -- switch --flake .#ne0san --impure # 初回
 #   sudo darwin-rebuild switch --flake ~/dotfiles#ne0san --impure # 二回目以降 (drsw)
 #
-# home-manager単体 (home.nix + nixvim.nixだけを反映)
+# home-manager単体 (home.nix + nixvim.nixだけを反映、macOS向け)
 #   nix run home-manager/master -- switch --flake .#ne0san --impure -b backup # 初回
 #   home-manager switch --flake ~/dotfiles#ne0san --impure -b backup # 二回目以降 (hmsw)
+#
+# home-manager単体 (home.nix + nixvim.nixだけを反映、Linux向け)
+# アーキテクチャに応じて ne0san-linux-x86_64 / ne0san-linux-aarch64 を使い分ける
+#   nix run home-manager/master -- switch --flake .#ne0san-linux-x86_64 --impure -b backup # 初回
+#   home-manager switch --flake ~/dotfiles#ne0san-linux-x86_64 --impure -b backup # 二回目以降 (hmsw)
 #
 # home-managerはmodule統合とstandaloneの併用が非対応で、同じプロファイルを
 # 取り合って壊れる(darwin-rebuildのたびにhome-managerコマンドが消える等)ため、
@@ -36,11 +41,24 @@
       system = "aarch64-darwin";
       username = builtins.getEnv "USER";
       # home.nixのunfreeパッケージ(1password-cli, claude-code)を許可するpkgs
-      pkgs = import nixpkgs {
-        inherit system;
-        config.allowUnfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
-          "1password-cli"
-          "claude-code"
+      unfreePredicate = pkg: builtins.elem (nixpkgs.lib.getName pkg) [
+        "1password-cli"
+        "claude-code"
+      ];
+      mkPkgs = sys: import nixpkgs {
+        system = sys;
+        config.allowUnfreePredicate = unfreePredicate;
+      };
+      pkgs = mkPkgs system;
+      # home-manager単体: home.nix(dotfiles) + nixvim.nixをdarwinを介さず単体で反映
+      mkHomeConfiguration = sys: home-manager.lib.homeManagerConfiguration {
+        pkgs = mkPkgs sys;
+        # home-manager単体モード: home.nix側でdrswを無効化させる
+        extraSpecialArgs = { inherit username; darwinManagesHomeManager = false; };
+        modules = [
+          nixvim.homeModules.nixvim
+          ./nix/home.nix
+          ./nix/nixvim.nix
         ];
       };
     in {
@@ -67,16 +85,11 @@
         specialArgs = { inherit username; };
       };
 
-      # home-manager: home.nix(dotfiles) + nixvim.nixをdarwinを介さず単体で反映
-      homeConfigurations."ne0san" = home-manager.lib.homeManagerConfiguration {
-        inherit pkgs;
-        # home-manager単体モード: home.nix側でdrswを無効化させる
-        extraSpecialArgs = { inherit username; darwinManagesHomeManager = false; };
-        modules = [
-          nixvim.homeModules.nixvim
-          ./nix/home.nix
-          ./nix/nixvim.nix
-        ];
-      };
+      # home-manager単体 (macOS): darwinを介さずhome.nix/nixvim.nixだけを反映
+      homeConfigurations."ne0san" = mkHomeConfiguration system;
+
+      # home-manager単体 (Linux): darwin/homebrew前提の設定を切り離した状態で反映
+      homeConfigurations."ne0san-linux-x86_64" = mkHomeConfiguration "x86_64-linux";
+      homeConfigurations."ne0san-linux-aarch64" = mkHomeConfiguration "aarch64-linux";
     };
 }

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,8 +1,10 @@
 { pkgs, lib, username, darwinManagesHomeManager ? true, ... }:
 let
+  isDarwin = pkgs.stdenv.isDarwin;
+  homeDirectory = if isDarwin then "/Users/${username}" else "/home/${username}";
   # ローカルのgit識別情報を読み込む（make git-identity で生成）
   # ~/.config/git-identity-{name,email} からユーザー情報を取得
-  configDir = "/Users/${username}/.config";
+  configDir = "${homeDirectory}/.config";
   gitUserName =
     let f = "${configDir}/git-identity-name";
     in if builtins.pathExists f
@@ -26,6 +28,12 @@ let
     subPackages = [ "cmd/tle" ];
   };
 
+  # home-manager単体反映時に使うflakeの出力名（プラットフォーム/アーキテクチャに対応）
+  homeFlakeAttr =
+    if isDarwin then "ne0san"
+    else if pkgs.system == "aarch64-linux" then "ne0san-linux-aarch64"
+    else "ne0san-linux-x86_64";
+
   # darwinManagesHomeManagerは、直近にどちらのflake出力で反映したか
   # (darwinConfigurations = true / homeConfigurations = false)を表す。
   # 使わない方のエイリアス(drsw/hmsw)はshellAbbrs/shellAliasesに含めず、
@@ -34,13 +42,13 @@ let
     drsw = "sudo USER=$USER darwin-rebuild switch --flake ~/dotfiles#ne0san --impure";
   };
   hmswAliasAttrs = lib.optionalAttrs (!darwinManagesHomeManager) {
-    hmsw = "home-manager switch --flake ~/dotfiles#ne0san --impure -b backup";
+    hmsw = "home-manager switch --flake ~/dotfiles#${homeFlakeAttr} --impure -b backup";
   };
 in
 {
   home.enableNixpkgsReleaseCheck = false;
   home.username = username;
-  home.homeDirectory = "/Users/${username}";
+  home.homeDirectory = homeDirectory;
   home.stateVersion = "25.05";
   home.packages = with pkgs; [
     devenv
@@ -172,7 +180,7 @@ in
   };
   programs.ghostty = {
     enable = true;
-    package = null;  # macOS用
+    package = if isDarwin then null else pkgs.ghostty;  # macOSはhomebrew版を使う
     enableFishIntegration = true;
 
     settings = {
@@ -182,6 +190,7 @@ in
         "MyricaM M"
       ];
       font-size = 11.5;
+    } // lib.optionalAttrs isDarwin {
       macos-option-as-alt = true;
     };
   };
@@ -284,10 +293,10 @@ in
       };
       init = {
         defaultBranch = "main";
-        templatedir = "/Users/${username}/.git-templates/git-secrets/";
+        templatedir = "${homeDirectory}/.git-templates/git-secrets/";
       };
       commit = {
-        template = "/Users/${username}/.stCommitMsg";
+        template = "${homeDirectory}/.stCommitMsg";
       };
     };
   };

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,8 +1,10 @@
 { pkgs, lib, username, darwinManagesHomeManager ? true, ... }:
 let
+  isDarwin = pkgs.stdenv.isDarwin;
+  homeDirectory = if isDarwin then "/Users/${username}" else "/home/${username}";
   # ローカルのgit識別情報を読み込む（make git-identity で生成）
   # ~/.config/git-identity-{name,email} からユーザー情報を取得
-  configDir = "/Users/${username}/.config";
+  configDir = "${homeDirectory}/.config";
   gitUserName =
     let f = "${configDir}/git-identity-name";
     in if builtins.pathExists f
@@ -40,7 +42,7 @@ in
 {
   home.enableNixpkgsReleaseCheck = false;
   home.username = username;
-  home.homeDirectory = "/Users/${username}";
+  home.homeDirectory = homeDirectory;
   home.stateVersion = "25.05";
   home.packages = with pkgs; [
     devenv
@@ -172,7 +174,7 @@ in
   };
   programs.ghostty = {
     enable = true;
-    package = null;  # macOS用
+    package = if isDarwin then null else pkgs.ghostty;  # macOSはhomebrew版を使う
     enableFishIntegration = true;
 
     settings = {
@@ -182,6 +184,7 @@ in
         "MyricaM M"
       ];
       font-size = 11.5;
+    } // lib.optionalAttrs isDarwin {
       macos-option-as-alt = true;
     };
   };
@@ -284,10 +287,10 @@ in
       };
       init = {
         defaultBranch = "main";
-        templatedir = "/Users/${username}/.git-templates/git-secrets/";
+        templatedir = "${homeDirectory}/.git-templates/git-secrets/";
       };
       commit = {
-        template = "/Users/${username}/.stCommitMsg";
+        template = "${homeDirectory}/.stCommitMsg";
       };
     };
   };

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,10 +1,8 @@
 { pkgs, lib, username, darwinManagesHomeManager ? true, ... }:
 let
-  isDarwin = pkgs.stdenv.isDarwin;
-  homeDirectory = if isDarwin then "/Users/${username}" else "/home/${username}";
   # ローカルのgit識別情報を読み込む（make git-identity で生成）
   # ~/.config/git-identity-{name,email} からユーザー情報を取得
-  configDir = "${homeDirectory}/.config";
+  configDir = "/Users/${username}/.config";
   gitUserName =
     let f = "${configDir}/git-identity-name";
     in if builtins.pathExists f
@@ -28,12 +26,6 @@ let
     subPackages = [ "cmd/tle" ];
   };
 
-  # home-manager単体反映時に使うflakeの出力名（プラットフォーム/アーキテクチャに対応）
-  homeFlakeAttr =
-    if isDarwin then "ne0san"
-    else if pkgs.system == "aarch64-linux" then "ne0san-linux-aarch64"
-    else "ne0san-linux-x86_64";
-
   # darwinManagesHomeManagerは、直近にどちらのflake出力で反映したか
   # (darwinConfigurations = true / homeConfigurations = false)を表す。
   # 使わない方のエイリアス(drsw/hmsw)はshellAbbrs/shellAliasesに含めず、
@@ -42,13 +34,13 @@ let
     drsw = "sudo USER=$USER darwin-rebuild switch --flake ~/dotfiles#ne0san --impure";
   };
   hmswAliasAttrs = lib.optionalAttrs (!darwinManagesHomeManager) {
-    hmsw = "home-manager switch --flake ~/dotfiles#${homeFlakeAttr} --impure -b backup";
+    hmsw = "home-manager switch --flake ~/dotfiles#ne0san --impure -b backup";
   };
 in
 {
   home.enableNixpkgsReleaseCheck = false;
   home.username = username;
-  home.homeDirectory = homeDirectory;
+  home.homeDirectory = "/Users/${username}";
   home.stateVersion = "25.05";
   home.packages = with pkgs; [
     devenv
@@ -180,7 +172,7 @@ in
   };
   programs.ghostty = {
     enable = true;
-    package = if isDarwin then null else pkgs.ghostty;  # macOSはhomebrew版を使う
+    package = null;  # macOS用
     enableFishIntegration = true;
 
     settings = {
@@ -190,7 +182,6 @@ in
         "MyricaM M"
       ];
       font-size = 11.5;
-    } // lib.optionalAttrs isDarwin {
       macos-option-as-alt = true;
     };
   };
@@ -293,10 +284,10 @@ in
       };
       init = {
         defaultBranch = "main";
-        templatedir = "${homeDirectory}/.git-templates/git-secrets/";
+        templatedir = "/Users/${username}/.git-templates/git-secrets/";
       };
       commit = {
-        template = "${homeDirectory}/.stCommitMsg";
+        template = "/Users/${username}/.stCommitMsg";
       };
     };
   };


### PR DESCRIPTION
home.nixがdarwinのホームディレクトリ(/Users/...)やghosttyの
macOS向け設定(homebrew版package、macos-option-as-alt)を
決め打ちしていたため、Linuxのhome-manager standalone構成では
そのまま使えなかった。pkgs.stdenv.isDarwinで分岐させ、
flake.nixにhomeConfigurations."ne0san-linux-x86_64"/ "ne0san-linux-aarch64"を追加した。既存のdarwinConfigurations/ homeConfigurations."ne0san"はsystem="aarch64-darwin"のまま変更していない。


Claude-Session: https://claude.ai/code/session_01AE5enHnBfPZVKAoqj93YSD