### PR TITLE
nix.sh: mac以外のホストではhome-manager単体反映に切り替える

### DIFF
--- a/nix/nix.sh
+++ b/nix/nix.sh
@@ -11,8 +11,13 @@ fi
 
 . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 
-# nix-darwin build
-sudo mv /etc/nix/nix.conf /etc/nix/nix.conf.before-nix-darwin
-sudo mv /etc/zshrc /etc/zshrc.before-nix-darwin
-sudo mv /etc/bashrc /etc/bashrc.before-nix-darwin
-sudo USER=$USER nix --extra-experimental-features "nix-command flakes" run nix-darwin -- switch --flake ~/dotfiles#ne0san --impure
+if [[ "$(uname)" == "Darwin" ]]; then
+  # nix-darwin build
+  sudo mv /etc/nix/nix.conf /etc/nix/nix.conf.before-nix-darwin
+  sudo mv /etc/zshrc /etc/zshrc.before-nix-darwin
+  sudo mv /etc/bashrc /etc/bashrc.before-nix-darwin
+  sudo USER=$USER nix --extra-experimental-features "nix-command flakes" run nix-darwin -- switch --flake ~/dotfiles#ne0san --impure
+else
+  # home-manager単体build (darwin以外のホスト向け)
+  nix --extra-experimental-features "nix-command flakes" run home-manager/master -- switch --flake ~/dotfiles#ne0san --impure -b backup
+fi


### PR DESCRIPTION
## Summary
- `nix/nix.sh` に `uname` によるmac判定分岐を追加
- ホストがDarwin (mac) の場合は従来通りnix-darwinのビルドを実行
- mac以外の場合はnix-darwin向けの`/etc`ファイル退避処理をスキップし、`flake.nix`に既に定義済みの`homeConfigurations."ne0san"`に対してhome-manager単体の初期switchコマンドを実行するようにした

## Test plan
- [ ] mac環境で`nix.sh`を実行し、従来通りnix-darwinのビルドが行われることを確認
- [ ] mac以外(Linux)の環境で`nix.sh`を実行し、home-manager単体のswitchが行われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEbqWLrbvjkuJwGeChAxM4

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEbqWLrbvjkuJwGeChAxM4)_