### PR TITLE
auto-session: jj使用時にセッションが自動復元されない問題を修正

### DIFF
--- a/nix/nixvim/plugins/editor.nix
+++ b/nix/nixvim/plugins/editor.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 
 {
   plugins = {
@@ -83,7 +83,43 @@
 
         auto_delete_empty_sessions = true;
 
-        git_use_branch_name = true;
+        # jj (Jujutsu) はコロケートリポジトリだと常にgitを detached HEAD にするため、
+        # 素の `git rev-parse --abbrev-ref HEAD` は常に "HEAD" を返してしまい、
+        # git管理下でつけたセッション名 (例: "main") と一致せず自動復元されなくなる。
+        # jjリポジトリの場合は @ の祖先にある最も近いbookmarkを代わりに使う。
+        git_use_branch_name = lib.nixvim.mkRaw ''
+          function(path)
+            local cwd = path or vim.fn.getcwd()
+
+            if vim.fn.finddir(".jj", cwd .. ";") ~= "" then
+              local out = vim.fn.system({
+                "jj",
+                "-R",
+                cwd,
+                "log",
+                "--no-graph",
+                "-r",
+                "heads(::@ & bookmarks())",
+                "-T",
+                "bookmarks.join(\",\")",
+              })
+              if vim.v.shell_error ~= 0 then
+                return nil
+              end
+              out = vim.trim(out)
+              if out == "" then
+                return nil
+              end
+              return vim.split(out, ",")[1]
+            end
+
+            local branch = vim.trim(vim.fn.system({ "git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD" }))
+            if vim.v.shell_error ~= 0 or branch == "" or branch == "HEAD" then
+              return nil
+            end
+            return branch
+          end
+        '';
 
         session_lens = {
           load_on_setup = true;


### PR DESCRIPTION
## Summary
- jjのcolocatedリポジトリでは gitのHEADが常にdetached状態になるため、`auto-session.nvim` の `git_use_branch_name = true` が内部で叩く `git rev-parse --abbrev-ref HEAD` が常に `"HEAD"` を返してしまい、git管理下で保存したセッション名（例: `main`）と一致せず自動復元されなかった
- `git_use_branch_name` をカスタム関数に置き換え、jjリポジトリ(`.jj` が存在する場合)は `jj log -r 'heads(::@ & bookmarks())'` で `@` の祖先にある最も近いbookmarkを使うようにした
- jjではない通常のgitリポジトリでは従来通り `git rev-parse --abbrev-ref HEAD` を使用（detached HEADの場合は `nil` を返す）

## Test plan
- [ ] `nix/nixvim/plugins/editor.nix` の変更をnixvimでビルドし、Lua構文エラーがないことを確認
- [ ] gitリポジトリで `git checkout main` 相当の状態でセッション保存 → 再度nvimを開いて自動復元されることを確認（既存動作の非退行）
- [ ] jjのcolocatedリポジトリ(`main` bookmark上に新しいchangeを作った状態)でnvimを開き、`main` ブランチ名ベースのセッションが自動復元されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hce4bkX7n51wN5fSyV15K2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hce4bkX7n51wN5fSyV15K2)_