### PR TITLE
jjuiのデフォルト設定とnvim連携を改善

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -339,6 +339,14 @@ in
 
   programs.jjui = {
     enable = true;
+    settings = {
+      revisions = {
+        revset = "all()"; # デフォルトのrevsetを全revisionに変更
+      };
+      preview = {
+        show_at_start = true; # デフォルトでpreviewペインを表示する
+      };
+    };
   };
 
   programs.direnv = {

--- a/nix/nixvim/keymaps/git.nix
+++ b/nix/nixvim/keymaps/git.nix
@@ -1,5 +1,18 @@
-{ ... }:
+{ pkgs, ... }:
 
+let
+  # jjui内でファイルをeditする際、nvimの:terminalから開いている場合は
+  # $NVIMに親nvimのソケットパスが設定されているため、それを使って
+  # 新規にnvimを入れ子起動するのではなく既存のnvimにタブとして開かせる
+  # (lazygitのos.editPreset = "nvim-remote"と同じ考え方)
+  jjuiNvimRemoteEdit = pkgs.writeShellScript "jjui-nvim-remote-edit" ''
+    if [ -n "$NVIM" ]; then
+      exec nvim --server "$NVIM" --remote-tab "$1"
+    else
+      exec nvim "$1"
+    fi
+  '';
+in
 {
   keymaps = [
     {
@@ -11,7 +24,7 @@
     {
       mode = "n";
       key = "<leader>jj";
-      action.__raw = ''function() Snacks.terminal.toggle("jjui", { win = { style = "float", backdrop = false, wo = { winblend = 15 } }, count = 5 }) end'';
+      action.__raw = ''function() Snacks.terminal.toggle("jjui", { win = { style = "float", backdrop = false, wo = { winblend = 15 } }, count = 5, env = { EDITOR = "${jjuiNvimRemoteEdit}", VISUAL = "${jjuiNvimRemoteEdit}" } }) end'';
       options.desc = "Jjui";
     }
     {


### PR DESCRIPTION
## Summary

- `programs.jjui.settings` に `revisions.revset = "all()"` と `preview.show_at_start = true` を追加し、jjuiのデフォルト表示を「全revisionをpreview付きで表示」に変更
- `<leader>jj` (`nix/nixvim/keymaps/git.nix`、Snacks.terminal経由でjjuiを開くキーマップ) に `EDITOR`/`VISUAL` の env を渡し、nvimの`:terminal`から開いている場合は `$NVIM` のソケット経由で既存のnvimにファイルをタブとして開かせるようにした。nvim外(通常のシェル)から開いた場合は今まで通り新規nvimを起動する。lazygitに既に設定されている `os.editPreset = "nvim-remote"` と同じ考え方の対応

## 実装の背景

- jjui本体には`os.editPreset`のような仕組みはなく、ファイルeditは単に`$EDITOR`(未設定時はnvim)をそのまま呼び出す実装だったため、nvim内のterminalからjjuiを開いていると入れ子でnvimが起動してしまっていた。これを避けるため、`$NVIM`が設定されている場合のみ`nvim --server "$NVIM" --remote-tab`で既存nvimにタブとして開かせるラッパースクリプトを`pkgs.writeShellScript`で生成し、jjuiのterminal起動時のみ`EDITOR`/`VISUAL`として渡すようにした(グローバルなEDITOR設定は変更していない)

## Test plan

- [ ] `home-manager switch --flake ~/dotfiles#ne0san --impure -b backup` (または darwin-rebuild) でビルド・反映できることを確認
- [ ] nvim内で `<leader>jj` からjjuiを開き、previewが最初から表示され、revsetが全件表示になっていることを確認
- [ ] nvim内で開いたjjuiからファイルをeditし、新しいnvimが入れ子起動されず既存nvimに新しいタブとして開かれることを確認
- [ ] nvim外(通常のターミナル)から `jjui` を実行した場合、editが従来通り新規nvimで開くことを確認

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MZJDv6W2v9uvGuZzxnar4

---
_Generated by [Claude Code](https://claude.ai/code/session_017MZJDv6W2v9uvGuZzxnar4)_